### PR TITLE
remove module and rootDir from the compilerOptions

### DIFF
--- a/sample.tsconfig.json
+++ b/sample.tsconfig.json
@@ -2,11 +2,9 @@
   "compileOnSave": true,
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
     "lib": ["es2020", "DOM"],
     "allowJs": true,
     "outDir": "build",
-    "rootDir": "src",
     "strict": false,
     "esModuleInterop": true,
     "resolveJsonModule": true


### PR DESCRIPTION
- Fixes typescript issue while using another svelte component from npm
- Fixes an issue with prop exports in svelte files that use typescript
- related [isssue](https://github.com/Elderjs/elderjs/issues/50#issuecomment-711474725)